### PR TITLE
Set maturity level to Incubator

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@
 layout: col-sidebar
 title: Secure Pipeline Verification Standard (SPVS)
 tags: spvs
-level: 4
+level: 2
 type: standards
 pitch: The Secure Pipeline Verification Standard (SPVS) Project goal is to develop a comprehensive standard that guides organizations in creating and maintaining secure software pipelines, encompassing the entire development and deployment lifecycle.
 headerimage: ./assets/images/SPVS_Banner.png


### PR DESCRIPTION
Hi! You are using a wrong maturity level for your project. This makes it appear as Flagship-level in some places, such as OWASP Nest. Please accept this PR or change the level yourself to `2` which is your current maturity level. Available levels:

* `4` = Flagship
* `3.5` = Production
* `3` = Lab
* `2` = Incubator

Thank you!
@bkimminich (for the OWASP Project Committee)