### PR TITLE
docs: fix broken links and typos in root markdown files

### DIFF
--- a/1.5/OWASP_SPVS_1.0_-en_Requirements.csv
+++ b/1.5/OWASP_SPVS_1.0_-en_Requirements.csv
@@ -1,4 +1,4 @@
-category_id,catagory_name,sub-category_id,sub-catagory_name,req_id,req_description,level 1,level 2,level 3,NIST,OWASP_CICD_Risk,cwe_mapping,cwe_description
+category_id,category_name,sub-category_id,sub-category_name,req_id,req_description,level 1,level 2,level 3,NIST,OWASP_CICD_Risk,cwe_mapping,cwe_description
 V1,Plan,V1.1,Identity and Access Management,V1.1.1,Verify that Multi-Factor Authentication (MFA) is enabled for accessing developer laptops and critical systems,,X,,"NIST 800-53: IA-2(1,2,12), IA-5",CICD-SEC-2,CWE-308;CWE-287,Use of Single-Factor Authentication;Improper Authentication - Weak authentication mechanisms
 V1,Plan,V1.1,Identity and Access Management,V1.1.2,Verify that all identities (human and programmatic) are managed through a centralized Identity Provider (IdP),,,X,NIST 800-53: AC-2,CICD-SEC-2,CWE-287,Improper Authentication - Inconsistent authentication mechanisms
 V1,Plan,V1.1,Identity and Access Management,V1.1.3,Verify all tools in documented software pipeline follow access permission as it relates to principle of least privilege,,,X,NIST 800-53: AC-6,CICD-SEC-2,CWE-250,Execution with Unnecessary Privileges - Excessive permissions

--- a/1.5/OWASP_SPVS_1.0_Categories_Overview.md
+++ b/1.5/OWASP_SPVS_1.0_Categories_Overview.md
@@ -9,9 +9,9 @@ This document outlines the stages and subcategories of the Secure Pipeline Verif
 | Column Name | Description |
 |---|---|
 | **Category_ID** | Unique identifier of the top-level SPVS category. Valid values are V1, V2, V3, V4, V5. See the list above for the corresponding names. |
-| **catagory_name** | Human readable name of the category that pairs with Category_ID. Valid values are Plan, Develop, Integrate, Release, Operate. |
+| **category_name** | Human readable name of the category that pairs with Category_ID. Valid values are Plan, Develop, Integrate, Release, Operate. |
 | **sub-category_id** | Identifier of the sub-category within the category. Format is V#.## where the first number matches Category_ID. See the lists above for valid values. |
-| **sub-catagory_name** | Human readable name of the sub-category that pairs with sub-category_id. Use the names listed above for each category. |
+| **sub-category_name** | Human readable name of the sub-category that pairs with sub-category_id. Use the names listed above for each category. |
 | **req_id** | Unique requirement identifier under a given sub-category. Format is V#.#.# for example V1.2.3. This provides traceability across documents and versions. |
 | **req_name** | Short title of the verification requirement. Keep it concise and specific so it is usable in reports and dashboards. |
 | **req_description** | Complete statement of the verification requirement. Write it as an objective condition that can be tested. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thank you for your interest in contributing to SPVS. We welcome all contribution
 
 1. Fork this repository and create a branch named descriptively (e.g., `add-sbom-verification-control`, `fix-v1.1.3-nist-mapping`).
 
-2. Add your proposed control(s) to `1.0/OWASP_SPVS_1.0_-en_Requirements.csv`. Keep the column order and formatting consistent with existing rows. If you're unsure of the category, pick the closest one and note it in your PR.
+2. Add your proposed control(s) to `1.5/OWASP_SPVS_1.0_-en_Requirements.csv`. Keep the column order and formatting consistent with existing rows. If you're unsure of the category, pick the closest one and note it in your PR.
 
 3. Open a pull request against the `main` branch. For new controls, your description should address:
    - What the control verifies

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Built on a **multi-tiered maturity model**, SPVS allows teams to start with **ba
 
 By embedding security at every phase and continuously validating controls, SPVS transforms traditional software pipelines into **secure, resilient, and compliant systems**. It provides a **standardized, measurable approach** for organizations to **design, implement, and sustain secure pipelines**, serving as a **critical enabler** of long-term DevSecOps success.
 
-- [SPVS Offical OWASP Web Page](https://owasp.org/www-project-spvs/)
+- [SPVS Official OWASP Web Page](https://owasp.org/www-project-spvs/)
 - [Join us on Slack @ #owasp-spvs](https://owasp.slack.com/archives/C0AQW879656)
 
 Why was the SPVS so calm during an incident? -> It had multi-factor resilience.
@@ -24,10 +24,10 @@ Why did the CI job take a coffee break? -> Too many Java exceptions!
 # Check out SPVS 1.5!
 - [Release 1.5 - AI Security - Community Feedback](/1.5/Release_Notes_OWASP_SPVS_1.5-AI-Pipeline-Security.md)
 - [How To Use SPVS](/1.5/OWASP_SPVS_1.0_How_To_Use_SPVS.md)
-- [Check out 1.0 Controls/Requirements](/www-project-spvs/1.5/OWASP_SPVS_1.0_-en_Requirements.csv)
-- [Check out Legend and Columns Overview](/www-project-spvs/1.5/OWASP_SPVS_1.0_Categories_Overview.md)
-- [How to Contribute to the SPVS](/www-project-spvs/CONTRIBUTING.md)
-- [How to Join the SPVS Team](/www-project-spvs/JOINING_THE_TEAM.md)
+- [Check out 1.0 Controls/Requirements](/1.5/OWASP_SPVS_1.0_-en_Requirements.csv)
+- [Check out Legend and Columns Overview](/1.5/OWASP_SPVS_1.0_Categories_Overview.md)
+- [How to Contribute to the SPVS](/CONTRIBUTING.md)
+- [How to Join the SPVS Team](/JOINING_THE_TEAM.md)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,5 +2,5 @@
 Contact the project leaders listed on the project webpage to report security issues
 
 ### Leaders
-* [Farshad Abasi](mailto:farshad.abasi@Owasp.org)
+* [Farshad Abasi](mailto:farshad.abasi@owasp.org)
 * [Cameron W](mailto:cameron.w@owasp.org)

--- a/info.md
+++ b/info.md
@@ -1,10 +1,10 @@
 ### SPVS Information
 * [GitHub Link](https://github.com/OWASP/www-project-spvs)
 
-### Offical Release
+### Official Release
 * [Release 1.5 - AI Security - Release Notes](https://github.com/OWASP/www-project-spvs/blob/main/1.5/Release_Notes_OWASP_SPVS_1.5-AI-Pipeline-Security.md)
 * [Release 1.5 - AI Security - Community Feedback](https://github.com/OWASP/www-project-spvs/blob/main/1.5/OWASP_SPVS_1.5-AI_-en_Requirements.csv)
-* [Release 1.0 (Oct 2025)](https://github.com/OWASP/www-project-spvs/)
+* [Release 1.0 (Oct 2025)](https://github.com/OWASP/www-project-spvs/blob/main/1.5/OWASP_SPVS_1.0_-en_Requirements.csv)
 
 ### Join us on OWASP Slack
 * [#owasp-spvs](https://owasp.slack.com/archives/C0AQW879656)
@@ -13,4 +13,4 @@
 * [How to Contribute](https://github.com/OWASP/www-project-spvs/blob/main/CONTRIBUTING.md)
 
 ### Social Media
-* [Linkedin](https://github.com/OWASP/www-project-spvs/blob/main/CONTRIBUTING.md)
+* [Linkedin](https://www.linkedin.com/company/owasp-spvs/)

--- a/leaders.md
+++ b/leaders.md
@@ -1,3 +1,3 @@
 ### Leaders
-* [Farshad Abasi](mailto:farshad.abasi@Owasp.org)
+* [Farshad Abasi](mailto:farshad.abasi@owasp.org)
 * [Cameron Walters](mailto:cameron.w@owasp.org)


### PR DESCRIPTION
## Summary

Documentation-only fixes across root markdown files and the v1.0 requirements CSV. No control content, mappings, or levels were changed.

- **README.md** — Fixed "Offical" → "Official" in the OWASP page link label; removed erroneous `/www-project-spvs/` prefix from four relative links (the prefix resolved to a non-existent subdirectory when viewed on GitHub, producing 404s)
- **CONTRIBUTING.md** — Updated stale directory reference from `1.0/` to `1.5/` in the contributor instructions; the `1.0/` directory does not exist in the repository
- **info.md** — Fixed "Offical Release" → "Official Release" heading typo; corrected "Release 1.0" link from the repo root URL to the specific CSV file; corrected LinkedIn link that was mistakenly pointing to CONTRIBUTING.md
- **SECURITY.md** — Normalized Farshad Abasi's email domain from `Owasp.org` to `owasp.org`
- **leaders.md** — Same email normalization
- **1.5/OWASP_SPVS_1.0_-en_Requirements.csv** — Fixed misspelled column headers: `catagory_name` → `category_name`, `sub-catagory_name` → `sub-category_name`
- **1.5/OWASP_SPVS_1.0_Categories_Overview.md** — Same spelling corrections in the matching column description table

## Test plan

- [ ] Verify all relative links in README.md resolve correctly on GitHub
- [ ] Confirm LinkedIn link opens the OWASP SPVS LinkedIn page
- [ ] Confirm Release 1.0 link opens the CSV file directly
- [ ] Confirm CSV header columns match the corrected names in Categories_Overview.md